### PR TITLE
Keep rack happy by passing nil back from the event handler hook

### DIFF
--- a/lib/email_events/services/handle_event.rb
+++ b/lib/email_events/services/handle_event.rb
@@ -15,6 +15,9 @@ class EmailEvents::Service::HandleEvent < EmailEvents::Service
         mailer.send :__handle_event, event_data, email_data
       end
     end
+
+    # no data to output back to Rack
+    nil
   end
 
   private


### PR DESCRIPTION
Reviewers:
- [x] @bmulholland 

Otherwise Rack tries to output the SentEmailEvent objects.
